### PR TITLE
Expect will cause redis-sentinel to not launch

### DIFF
--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -4,7 +4,6 @@
 start on (local-filesystems and runlevel [2345])
 stop on runlevel [016]
 respawn
-expect fork
 limit nofile 20000 65000
 
 pre-start script


### PR DESCRIPTION
Using expect fork will cause the upstart script to believe that redis-sentinel is running when it isn't. This only occurs on boot.